### PR TITLE
Added 'pipenv run migrate' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ You can update the `styles/index.scss` or create new `.scss` files inside `style
 ### Components
 Add more files into your `./src/js/components` or styles folder as you need them and import them into your current files as needed.
 
-💡Note: There is an example using the Context API inside `pages/demo.js`;
+💡Note: There is an example using the Context API inside `views/demo.js`;
 
-### pages (Components)
-Add more files into your `./src/js/pages` and import them in `./src/js/layout.jsx`.
+### Views (Components)
+Add more files into your `./src/js/views` and import them in `./src/js/layout.jsx`.
 
 ### Context
 This boilerplate comes with a centralized general Context API. The file `./src/js/store/flux.js` has a base structure for the store, we encourage you to change it and adapt it to your needs.
@@ -22,7 +22,7 @@ This boilerplate comes with a centralized general Context API. The file `./src/j
 React Context [docs](https://reactjs.org/docs/context.html)
 BreathCode Lesson [view](https://content.breatheco.de/lesson/react-hooks-explained)
 
-The `Provider` is already set. You can consume from any component using the useContext hook to get the `store` and `actions` from the Context. Check `/pages/demo.js` to see a demo.
+The `Provider` is already set. You can consume from any component using the useContext hook to get the `store` and `actions` from the Context. Check `/views/demo.js` to see a demo.
 
 ```jsx
 import { Context } from "../store/appContext";
@@ -47,8 +47,9 @@ It is recomended to install the backend first, make sure you have Python 3.8, Pi
 | MySQL		| mysql://username:password@localhost:port/example	|
 | Postgress	| postgres://username:password@localhost:5432/example 	|
 
-3. Run the migrations: `$ pipenv run upgrade`
-4. Run the application: `$ pipenv run start
+4. Migrate the migrations: `$ pipenv run migrate` skip this step if there are no changes on Modules Columns
+5. Run the migrations: `$ pipenv run upgrade`
+6. Run the application: `$ pipenv run start
 
 
 ### Front-End Manual Installation:

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ You can update the `styles/index.scss` or create new `.scss` files inside `style
 ### Components
 Add more files into your `./src/js/components` or styles folder as you need them and import them into your current files as needed.
 
-💡Note: There is an example using the Context API inside `views/demo.js`;
+💡Note: There is an example using the Context API inside `pages/demo.js`;
 
-### Views (Components)
-Add more files into your `./src/js/views` and import them in `./src/js/layout.jsx`.
+### pages (Components)
+Add more files into your `./src/js/pages` and import them in `./src/js/layout.jsx`.
 
 ### Context
 This boilerplate comes with a centralized general Context API. The file `./src/js/store/flux.js` has a base structure for the store, we encourage you to change it and adapt it to your needs.
@@ -22,7 +22,7 @@ This boilerplate comes with a centralized general Context API. The file `./src/j
 React Context [docs](https://reactjs.org/docs/context.html)
 BreathCode Lesson [view](https://content.breatheco.de/lesson/react-hooks-explained)
 
-The `Provider` is already set. You can consume from any component using the useContext hook to get the `store` and `actions` from the Context. Check `/views/demo.js` to see a demo.
+The `Provider` is already set. You can consume from any component using the useContext hook to get the `store` and `actions` from the Context. Check `/pages/demo.js` to see a demo.
 
 ```jsx
 import { Context } from "../store/appContext";


### PR DESCRIPTION
Only when Columns are added or modified, before the  `$ pipenv run upgrade` we need to run `$ pipenv run migrate`.