### PR TITLE
Fix for occasional backend url generation failure

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,14 +11,14 @@ ports:
     onOpen: ignore
 tasks:
   - init: >
-      (cp -n .env.example .env || true) && 
+      (cp -n .env.example .env || true) &&
       pipenv install &&
       psql -U gitpod -c 'CREATE DATABASE example;' &&
       psql -U gitpod -c 'CREATE EXTENSION unaccent;' -d example &&
       bash database.sh &&
       python docs/assets/greeting.py back
   - command: >
-      ((sed -i /BACKEND_URL/d .env && echo "" >> .env && echo "BACKEND_URL=https://3001-${GITPOD_WORKSPACE_URL:8}" >> .env) || true) && 
+      echo BACKEND_URL=$(gp url 3001) >> .env && 
       npm install &&
       python docs/assets/greeting.py front
     openMode: split-right


### PR DESCRIPTION
Update `BACKEND_URL` to use the [gp command line utility](https://www.gitpod.io/docs/references/gitpod-cli), this appears to fix the occasional failure to generate the env variable on container start.

Also evidently removed a trailing space on line 14.