### PR TITLE
Made container creation not DIAF if invalid code is committed.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 	// This can be used to network with other containers or the host.
 	"forwardPorts": [3000, 3001],
 
-	"onCreateCommand": "(cp .env.example .env || true) && pipenv install && bash database.sh",
+	"onCreateCommand": "(cp .env.example .env || echo \".env creation failed\"); (pipenv install || echo \"pipenv install failed\"); (bash database.sh || echo \"database.sh failed\");",
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "python docs/assets/greeting.py both > /workspaces/.codespaces/shared/first-run-notice.txt && npm install",
 


### PR DESCRIPTION
Due to how container startup happens, if there's a syntax error in some python files the container will DIAF on startup and lead to the Codespace starting up in safe mode.  A safe mode container can not push code to a repo, so a student can get themselves into a situation where they can not fix their problems in Codespaces.  This patch prevents that situation from happening.